### PR TITLE
Fix car status progression

### DIFF
--- a/app/Http/Controllers/CarController.php
+++ b/app/Http/Controllers/CarController.php
@@ -33,23 +33,30 @@ class CarController extends Controller
     return redirect()->route('cars.index')->with('success', 'Машин амжилттай бүртгэгдлээ!');
 }
 
-    public function updateStatus(Car $car)
-{
-    $statuses = ['prepared', 'china_border', 'ub_arrived', 'sold'];
+    public function updateStatus(Request $request, Car $car)
+    {
+    $statuses = ['prepared', 'china_border', 'mongolia_border', 'ub_arrived', 'sold'];
     $currentIndex = array_search($car->status, $statuses);
 
     if ($currentIndex !== false && $currentIndex < count($statuses) - 1) {
         $nextStatus = $statuses[$currentIndex + 1];
 
+        // Шинэ өгөгдлүүдийг хадгалах
+        $car->fill($request->only([
+            'permit_cost_yuan',
+            'customs_tax_mnt',
+            'selling_price_mnt',
+        ]));
+
         // Хяналт: дараагийн шатанд шаардлагатай утгууд байна уу?
         if ($nextStatus === 'china_border' && empty($car->permit_cost_yuan)) {
             return back()->with('error', 'Хятадын хил дээр ирэхийн тулд бичиг, зардлын мэдээллийг оруулна уу.');
         }
-        if ($nextStatus === 'ub_arrived' && empty($car->customs_tax_mnt)) {
+        if ($nextStatus === 'mongolia_border' && empty($car->customs_tax_mnt)) {
             return back()->with('error', 'Монгол татварын мэдээлэл дутуу байна.');
         }
-        if ($nextStatus === 'sold' && empty($car->selling_price_mnt)) {
-            return back()->with('error', 'Зарах үнийг оруулсны дараа зарлагдсан төлөвт оруулна уу.');
+        if ($nextStatus === 'ub_arrived' && empty($car->selling_price_mnt)) {
+            return back()->with('error', 'Зарах үнийг оруулсны дараа УБ-д ирсэн төлөвт оруулна уу.');
         }
 
         $car->status = $nextStatus;

--- a/database/migrations/2025_07_27_095837_create_cars_table.php
+++ b/database/migrations/2025_07_27_095837_create_cars_table.php
@@ -28,7 +28,7 @@ return new class extends Migration
     $table->decimal('exchange_rate', 8, 2)->nullable();
     $table->decimal('total_cost_mnt', 15, 2)->nullable();
     $table->decimal('selling_price_mnt', 15, 2)->nullable();
-    $table->enum('status', ['prepared', 'china_border', 'ub_arrived', 'sold'])->default('prepared');
+    $table->enum('status', ['prepared', 'china_border', 'mongolia_border', 'ub_arrived', 'sold'])->default('prepared');
     $table->date('ub_arrived_date')->nullable();
     $table->timestamps();
 });

--- a/resources/views/cars/index.blade.php
+++ b/resources/views/cars/index.blade.php
@@ -54,13 +54,16 @@
                                         $statusLabels = [
             'prepared' => 'Бэлтгэгдсэн',
             'china_border' => 'Хятад хил дээр',
+            'mongolia_border' => 'Монгол хил дээр',
             'ub_arrived' => 'УБ-д ирсэн',
             'sold' => 'Зарагдсан',
         ];
     @endphp
     {{ $statusLabels[$car->status] ?? $car->status }}</td>
                         <td class="p-2">
-    @if($car->status === 'mongolia_border')
+    @if($car->status === 'china_border')
+        @include('cars.partials.mongolia_border_modal', ['car' => $car])
+    @elseif($car->status === 'mongolia_border')
         @include('cars.partials.ub_arrived_modal', ['car' => $car])
     @elseif($car->status !== 'sold')
         <form action="{{ route('cars.status', $car) }}" method="POST">


### PR DESCRIPTION
## Summary
- accept request data in updateStatus
- add missing `mongolia_border` step to car statuses
- show Mongolia border action in car index
- fix cars table migration enum

## Testing
- `composer test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_688622ad98e4832f89db011f2d43d68e